### PR TITLE
Update `maven-dependency-plugin` to version 3.8.1, enable `mvn dependency:go-offline` in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY resource-catalogue-service/pom.xml ./resource-catalogue-service/
 COPY matomo/pom.xml ./matomo/
 
 ## Go offline to cache dependencies
-#RUN mvn dependency:go-offline -B
+RUN mvn dependency:go-offline -B
 
 # Copy the full source
 COPY . .

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <javax.mail-version>1.4.3</javax.mail-version>
         <jaxb2-maven-plugin.version>2.5.0</jaxb2-maven-plugin.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.1.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
         <typescript-generator-maven-plugin.version>2.16.538</typescript-generator-maven-plugin.version>


### PR DESCRIPTION
This commit fixes `mvn dependency:go-offline` failing due to missing dependencies, even though the dependencies are present in the Reactor build. This was fixed in `maven-dependency-plugin` 3.1.2.